### PR TITLE
Endpoint para listar pre config e mostrá-la

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1,7 +1,7 @@
 from flask import Flask
 from flask_restful import Api
 from src.resources.available import AvailablePreConfigs
-from src.resources.pre_config import PreConfigs
+from src.resources.pre_config import PreConfigs, PreConfigsWithID
 from src.resources.import_metrics import ImportMetrics
 from flask_mongoengine import MongoEngine
 from .config import MONGO_SETTINGS
@@ -30,6 +30,8 @@ def create_app(is_testing=False):
     api.add_resource(ImportMetrics, "/import-metrics")
 
     api.add_resource(PreConfigs, "/pre-configs")
+
+    api.add_resource(PreConfigsWithID, "/pre-configs/<string:pre_config_id>")
 
     db = MongoEngine(app)
 

--- a/src/model/pre_config.py
+++ b/src/model/pre_config.py
@@ -21,18 +21,8 @@ class PreConfig(me.Document):
         }
 
     def to_lean_json(self):
-        return{
+        return {
             "_id": str(self.pk),
             "name": self.name,
             "created_at": str(self.created_at()),
-        }
-
-    def to_goal_json(self):
-        return{
-            "characteristics": self.characteristics,
-            "subcharacteristics": self.subcharacteristics,
-            "measures": self.measures,
-            "characteristics_weights": self.characteristics_weights,
-            "subcharacteristics_weights": self.subcharacteristics_weights,
-            "measures_weights": self.measures_weights,
         }

--- a/src/model/pre_config.py
+++ b/src/model/pre_config.py
@@ -19,3 +19,20 @@ class PreConfig(me.Document):
             "measures": self.measures,
             "created_at": str(self.created_at()),
         }
+
+    def to_lean_json(self):
+        return{
+            "_id": str(self.pk),
+            "name": self.name,
+            "created_at": str(self.created_at()),
+        }
+
+    def to_goal_json(self):
+        return{
+            "characteristics": self.characteristics,
+            "subcharacteristics": self.subcharacteristics,
+            "measures": self.measures,
+            "characteristics_weights": self.characteristics_weights,
+            "subcharacteristics_weights": self.subcharacteristics_weights,
+            "measures_weights": self.measures_weights,
+        }

--- a/src/resources/pre_config.py
+++ b/src/resources/pre_config.py
@@ -24,3 +24,19 @@ class PreConfigs(Resource):
         for db_pre_config in PreConfig.objects():
             pre_config.append(db_pre_config.to_lean_json())
         return pre_config
+
+class PreConfigsWithID(Resource):
+    def get(self, pre_config_id):
+        try:
+            pre_config = PreConfig.objects.with_id(pre_config_id)
+            if pre_config is None:
+                return{
+                    "Error" : f"There is no pre configurations with ID {pre_config_id}"
+                }, requests.codes.not_found
+
+            return pre_config.to_json()
+        except me.errors.ValidationError:
+            return {
+                "Error" : f"{pre_config_id} is not a valid ID"
+            }, requests.codes.not_found
+        

--- a/src/resources/pre_config.py
+++ b/src/resources/pre_config.py
@@ -17,3 +17,10 @@ class PreConfigs(Resource):
             }, requests.codes.unprocessable_entity
 
         return pre_config.to_json(), requests.codes.created
+
+    def get(self):
+        pre_config = []
+
+        for db_pre_config in PreConfig.objects():
+            pre_config.append(db_pre_config.to_lean_json())
+        return pre_config

--- a/src/resources/pre_config.py
+++ b/src/resources/pre_config.py
@@ -20,7 +20,7 @@ class PreConfigs(Resource):
         pre_config, json_msg = self.get_pre_config(pre_config_id)
 
         if pre_config is None:
-            return json_msg, requests.codes.not_found
+            return simple_error_response(json_msg, requests.codes.not_found)
 
         return pre_config.to_json(), requests.codes.ok
 

--- a/src/resources/pre_config.py
+++ b/src/resources/pre_config.py
@@ -25,14 +25,6 @@ class PreConfigs(Resource):
             pre_config.append(db_pre_config.to_lean_json())
         return pre_config
 
-    def get(self):
-        pre_config_goal = []
-
-        for db_pre_config_goal in PreConfig.objects():
-            pre_config_goal.append(db_pre_config_goal.to_goal_json())
-        return pre_config_goal
-
-
 class PreConfigsWithID(Resource):
     def get(self, pre_config_id):
         try:
@@ -48,18 +40,3 @@ class PreConfigsWithID(Resource):
                 "Error": f"{pre_config_id} is not a valid ID"
             }, requests.codes.not_found
 
-
-class PreConfigsGoals(Resource):
-    def get(self, pre_config2):
-        try:
-            pre_config_goal = PreConfig.objects.goals(pre_config2)
-            if pre_config_goal is None:
-                return{
-                    "Error": f"There is no goals for that pre-config{pre_config2}"
-                }, requests.codes.not_found
-
-            return pre_config_goal.to_json()
-        except me.errors.ValidationError:
-            return{
-                "Error": f"{pre_config2} is not a valid goal"
-            }, requests.codes.not_found

--- a/src/resources/pre_config.py
+++ b/src/resources/pre_config.py
@@ -25,18 +25,41 @@ class PreConfigs(Resource):
             pre_config.append(db_pre_config.to_lean_json())
         return pre_config
 
+    def get(self):
+        pre_config_goal = []
+
+        for db_pre_config_goal in PreConfig.objects():
+            pre_config_goal.append(db_pre_config_goal.to_goal_json())
+        return pre_config_goal
+
+
 class PreConfigsWithID(Resource):
     def get(self, pre_config_id):
         try:
             pre_config = PreConfig.objects.with_id(pre_config_id)
             if pre_config is None:
                 return{
-                    "Error" : f"There is no pre configurations with ID {pre_config_id}"
+                    "Error": f"There is no pre configurations with ID {pre_config_id}"
                 }, requests.codes.not_found
 
             return pre_config.to_json()
         except me.errors.ValidationError:
             return {
-                "Error" : f"{pre_config_id} is not a valid ID"
+                "Error": f"{pre_config_id} is not a valid ID"
             }, requests.codes.not_found
-        
+
+
+class PreConfigsGoals(Resource):
+    def get(self, pre_config2):
+        try:
+            pre_config_goal = PreConfig.objects.goals(pre_config2)
+            if pre_config_goal is None:
+                return{
+                    "Error": f"There is no goals for that pre-config{pre_config2}"
+                }, requests.codes.not_found
+
+            return pre_config_goal.to_json()
+        except me.errors.ValidationError:
+            return{
+                "Error": f"{pre_config2} is not a valid goal"
+            }, requests.codes.not_found

--- a/tests/integration/test_preconfig.py
+++ b/tests/integration/test_preconfig.py
@@ -1,38 +1,24 @@
-import pytest
-import mongoengine as me
 from src.model.pre_config import PreConfig
 
-CREATE_PRE_CONFIG_PARAMS = {
-    "characteristics": {
-        "reliability": {
-            "expected_value": 70,
-            "weight": 50,
-            "subcharacteristics": ["testing_status"],
-            "weights": {"testing_status": 100.0},
-        },
-        "maintainability": {
-            "expected_value": 30,
-            "weight": 50,
-            "subcharacteristics": ["modifiability"],
-            "weights": {"modifiability": 100.0},
-        },
-    },
-    "subcharacteristics": {
-        "testing_status": {
-            "weights": {"passed_tests": 100.0},
-            "measures": ["passed_tests"],
-        },
-        "modifiability": {
-            "weights": {"non_complex_file_density": 100.0},
-            "measures": ["non_complex_file_density"],
-        },
-    },
-    "measures": ["passed_tests", "non_complex_file_density"],
+EMPTY_LEVELS_CREATE_PRE_CONFIG_PARAMS = {
+    "characteristics": [""],
+    "subcharacteristics": [""],
+    "measures": [""],
+    "characteristics_weights": [""],
+    "subcharacteristics_weights": [""],
+    "measures_weights": [""],
+}
+
+
+EMPTY_LEVELS_PRE_CONFIG_LEAN_PARAMS = {
+    "_id": [""],
+    "name": [""],
+    "created_at": [""],
 }
 
 
 def test_create_pre_config_success(client):
-    params = {"name": "Pre config 1", **CREATE_PRE_CONFIG_PARAMS}
+    params = {"name": "Pre config 1", **EMPTY_LEVELS_CREATE_PRE_CONFIG_PARAMS}
 
     response = client.post("/pre-configs", json=params)
 
@@ -49,7 +35,7 @@ def test_create_pre_config_not_unique_name(client):
     pre_config_one = PreConfig(name="Name one")
     pre_config_one.save()
 
-    params = {"name": "Name one", **CREATE_PRE_CONFIG_PARAMS}
+    params = {"name": "Name one", **EMPTY_LEVELS_CREATE_PRE_CONFIG_PARAMS}
 
     response = client.post("/pre-configs", json=params)
 
@@ -57,32 +43,134 @@ def test_create_pre_config_not_unique_name(client):
     assert response.json == {"error": "The pre config name is already in use"}
 
 
-def test_create_pre_config_invalid_field_types(client):
-    pre_config_one = PreConfig(name="Name one")
+""""{  
+        "characteristics": {
+        "reliability": {
+            "expected_value": 70,
+            "weight": 50,
+            "subcharacteristics": ["testing_status"],
+            "weights": {"testing_status": 100.0}
+        },
+        "maintainability": {
+            "expected_value": 30,
+            "weight": 50,
+            "subcharacteristics": ["modifiability"],
+            "weights": {"modifiability": 100.0}
+        }
+    },
+    "subcharacteristics": {
+        "testing_status": {
+            "weights": {"passed_tests": 100.0},
+            "measures": ["passed_tests"]
+        },
+        "modifiability": {
+            "weights": {"non_complex_file_density": 100.0},
+            "measures": ["non_complex_file_density"]
+        }
+    },
+    "measures": ["passed_tests", "non_complex_file_density"]
+}
+""" ""
+
+
+def test_pre_config(client):
+    pre_config_one = PreConfig(
+        name="abc",
+        characteristics={
+            "reliability": {
+                "weight": 50,
+                "subcharacteristics": ["testing_status"],
+                "weights": {"testing_status": 100.0},
+            },
+            "maintainability": {
+                "weight": 50,
+                "subcharacteristics": ["modifiability"],
+                "weights": {"modifiability": 100.0},
+            },
+        },
+        subcharacteristics={
+            "testing_status": {
+                "weights": {"passed_tests": 100.0},
+                "measures": ["passed_tests"],
+            },
+            "modifiability": {
+                "weights": {"non_complex_file_density": 100.0},
+                "measures": ["non_complex_file_density"],
+            },
+        },
+        measures=["passed_tests", "non_complex_file_density"],
+    )
     pre_config_one.save()
 
-    params = {
-        "name": "Name two",
-        "characteristics": [],
-        "subcharacteristics": [],
-        "measures": {},
-    }
+    response = client.get("/pre-configs")
 
-    with pytest.raises(me.errors.ValidationError) as error:
-        client.post("/pre-configs", json=params)
+    assert response.status_code == 200
 
-    expected_msg = (
-        "ValidationError (PreConfig:None) (Only dictionaries may be used in a DictField: "
-        + "['characteristics', 'subcharacteristics'] Only lists and tuples may be used in a list field: ['measures'])"
+    all_pre_configs = [x.to_lean_json() for x in PreConfig.objects.all()]
+    assert response.json == all_pre_configs
+
+
+""" 
+
+Testar o endpoint /pre-configs
+
+- Mockar pre configs no banco de dados, ou seja criar pre configs "falsas" no BD
+
+- Realizar a chamada do endpoint client.get("/pre-configs")
+
+- Dar os asserts necessários
+
+
+Testar o endpoint /pre-configs/<pre_config_id>
+
+- Mockar uma pre config no BD com o mesmo id que vai ser chamado
+
+- Realizar a chamada no endpoint client.get("/pre-configs/id_fake_escolhido")
+
+- Dar os asserts
+
+"""
+
+
+def test_unique_pre_config(client):
+    pre_config_two = PreConfig(
+        name="def",
+        characteristics={
+            "reliability": {
+                "weight": 50,
+                "subcharacteristics": ["testing_status"],
+                "weights": {"testing_status": 100.0},
+            },
+            "maintainability": {
+                "weight": 50,
+                "subcharacteristics": ["modifiability"],
+                "weights": {"modifiability": 100.0},
+            },
+        },
+        subcharacteristics={
+            "testing_status": {
+                "weights": {"passed_tests": 100.0},
+                "measures": ["passed_tests"],
+            },
+            "modifiability": {
+                "weights": {"non_complex_file_density": 100.0},
+                "measures": ["non_complex_file_density"],
+            },
+        },
+        measures=["passed_tests", "non_complex_file_density"],
     )
+    pre_config_two.save()
 
-    assert expected_msg in str(error.value)
+    response = client.get("/pre-configs/" + str(pre_config_two.pk))
+
+    assert response.status_code == 200
+
+    assert response.json == pre_config_two.to_json()
 
 
-def test_preconfig_wrong_path(client):
-    response = client.post(
-        "/selecte-pre-config",
+def test_preconfig_lean_wrong_path(client):
+    response = client.get(
+        "/pre-config",
         json={},
     )
-
     assert response.status_code == 404

--- a/tests/integration/test_preconfig.py
+++ b/tests/integration/test_preconfig.py
@@ -62,7 +62,7 @@ def test_create_pre_config_not_unique_name(client):
     assert response.json == {"error": "The pre config name is already in use"}
 
 
-def test_pre_config(client):
+def test_pre_configs_list(client):
     pre_config_one = PreConfig(name="abc", **CREATE_PRE_CONFIG_PARAMS)
     pre_config_one.save()
 
@@ -75,7 +75,7 @@ def test_pre_config(client):
     assert response.json == all_pre_configs
 
 
-def test_unique_pre_config(client):
+def test_pre_config_show(client):
     pre_config = PreConfig(name="def", **CREATE_PRE_CONFIG_PARAMS)
     pre_config.save()
 

--- a/tests/integration/test_preconfig.py
+++ b/tests/integration/test_preconfig.py
@@ -16,6 +16,32 @@ EMPTY_LEVELS_PRE_CONFIG_LEAN_PARAMS = {
     "created_at": [""],
 }
 
+PRE_CONFIG_FIELDS_EXAMPLE = {
+    "characteristics": {
+        "reliability": {
+            "weight": 50,
+            "subcharacteristics": ["testing_status"],
+            "weights": {"testing_status": 100.0},
+        },
+        "maintainability": {
+            "weight": 50,
+            "subcharacteristics": ["modifiability"],
+            "weights": {"modifiability": 100.0},
+        },
+    },
+    "subcharacteristics": {
+        "testing_status": {
+            "weights": {"passed_tests": 100.0},
+            "measures": ["passed_tests"],
+        },
+        "modifiability": {
+            "weights": {"non_complex_file_density": 100.0},
+            "measures": ["non_complex_file_density"],
+        },
+    },
+    "measures": ["passed_tests", "non_complex_file_density"],
+}
+
 
 def test_create_pre_config_success(client):
     params = {"name": "Pre config 1", **EMPTY_LEVELS_CREATE_PRE_CONFIG_PARAMS}
@@ -43,63 +69,8 @@ def test_create_pre_config_not_unique_name(client):
     assert response.json == {"error": "The pre config name is already in use"}
 
 
-""""{  
-        "characteristics": {
-        "reliability": {
-            "expected_value": 70,
-            "weight": 50,
-            "subcharacteristics": ["testing_status"],
-            "weights": {"testing_status": 100.0}
-        },
-        "maintainability": {
-            "expected_value": 30,
-            "weight": 50,
-            "subcharacteristics": ["modifiability"],
-            "weights": {"modifiability": 100.0}
-        }
-    },
-    "subcharacteristics": {
-        "testing_status": {
-            "weights": {"passed_tests": 100.0},
-            "measures": ["passed_tests"]
-        },
-        "modifiability": {
-            "weights": {"non_complex_file_density": 100.0},
-            "measures": ["non_complex_file_density"]
-        }
-    },
-    "measures": ["passed_tests", "non_complex_file_density"]
-}
-""" ""
-
-
 def test_pre_config(client):
-    pre_config_one = PreConfig(
-        name="abc",
-        characteristics={
-            "reliability": {
-                "weight": 50,
-                "subcharacteristics": ["testing_status"],
-                "weights": {"testing_status": 100.0},
-            },
-            "maintainability": {
-                "weight": 50,
-                "subcharacteristics": ["modifiability"],
-                "weights": {"modifiability": 100.0},
-            },
-        },
-        subcharacteristics={
-            "testing_status": {
-                "weights": {"passed_tests": 100.0},
-                "measures": ["passed_tests"],
-            },
-            "modifiability": {
-                "weights": {"non_complex_file_density": 100.0},
-                "measures": ["non_complex_file_density"],
-            },
-        },
-        measures=["passed_tests", "non_complex_file_density"],
-    )
+    pre_config_one = PreConfig(name="abc", **PRE_CONFIG_FIELDS_EXAMPLE)
     pre_config_one.save()
 
     response = client.get("/pre-configs")
@@ -107,65 +78,18 @@ def test_pre_config(client):
     assert response.status_code == 200
 
     all_pre_configs = [x.to_lean_json() for x in PreConfig.objects.all()]
+
     assert response.json == all_pre_configs
 
 
-""" 
-
-Testar o endpoint /pre-configs
-
-- Mockar pre configs no banco de dados, ou seja criar pre configs "falsas" no BD
-
-- Realizar a chamada do endpoint client.get("/pre-configs")
-
-- Dar os asserts necessários
-
-
-Testar o endpoint /pre-configs/<pre_config_id>
-
-- Mockar uma pre config no BD com o mesmo id que vai ser chamado
-
-- Realizar a chamada no endpoint client.get("/pre-configs/id_fake_escolhido")
-
-- Dar os asserts
-
-"""
-
-
 def test_unique_pre_config(client):
-    pre_config_two = PreConfig(
-        name="def",
-        characteristics={
-            "reliability": {
-                "weight": 50,
-                "subcharacteristics": ["testing_status"],
-                "weights": {"testing_status": 100.0},
-            },
-            "maintainability": {
-                "weight": 50,
-                "subcharacteristics": ["modifiability"],
-                "weights": {"modifiability": 100.0},
-            },
-        },
-        subcharacteristics={
-            "testing_status": {
-                "weights": {"passed_tests": 100.0},
-                "measures": ["passed_tests"],
-            },
-            "modifiability": {
-                "weights": {"non_complex_file_density": 100.0},
-                "measures": ["non_complex_file_density"],
-            },
-        },
-        measures=["passed_tests", "non_complex_file_density"],
-    )
-    pre_config_two.save()
+    pre_config = PreConfig(name="def", **PRE_CONFIG_FIELDS_EXAMPLE)
+    pre_config.save()
 
-    response = client.get("/pre-configs/" + str(pre_config_two.pk))
+    response = client.get(f"/pre-configs/{pre_config.pk}")
 
     assert response.status_code == 200
-
-    assert response.json == pre_config_two.to_json()
+    assert response.json == pre_config.to_json()
 
 
 def test_preconfig_lean_wrong_path(client):
@@ -173,4 +97,5 @@ def test_preconfig_lean_wrong_path(client):
         "/pre-config",
         json={},
     )
+
     assert response.status_code == 404

--- a/tests/integration/test_preconfig.py
+++ b/tests/integration/test_preconfig.py
@@ -1,29 +1,15 @@
 from src.model.pre_config import PreConfig
 
-EMPTY_LEVELS_CREATE_PRE_CONFIG_PARAMS = {
-    "characteristics": [""],
-    "subcharacteristics": [""],
-    "measures": [""],
-    "characteristics_weights": [""],
-    "subcharacteristics_weights": [""],
-    "measures_weights": [""],
-}
-
-
-EMPTY_LEVELS_PRE_CONFIG_LEAN_PARAMS = {
-    "_id": [""],
-    "name": [""],
-    "created_at": [""],
-}
-
-PRE_CONFIG_FIELDS_EXAMPLE = {
+CREATE_PRE_CONFIG_PARAMS = {
     "characteristics": {
         "reliability": {
+            "expected_value": 70,
             "weight": 50,
             "subcharacteristics": ["testing_status"],
             "weights": {"testing_status": 100.0},
         },
         "maintainability": {
+            "expected_value": 30,
             "weight": 50,
             "subcharacteristics": ["modifiability"],
             "weights": {"modifiability": 100.0},
@@ -43,8 +29,15 @@ PRE_CONFIG_FIELDS_EXAMPLE = {
 }
 
 
+EMPTY_LEVELS_PRE_CONFIG_LEAN_PARAMS = {
+    "_id": [""],
+    "name": [""],
+    "created_at": [""],
+}
+
+
 def test_create_pre_config_success(client):
-    params = {"name": "Pre config 1", **EMPTY_LEVELS_CREATE_PRE_CONFIG_PARAMS}
+    params = {"name": "Pre config 1", **CREATE_PRE_CONFIG_PARAMS}
 
     response = client.post("/pre-configs", json=params)
 
@@ -61,7 +54,7 @@ def test_create_pre_config_not_unique_name(client):
     pre_config_one = PreConfig(name="Name one")
     pre_config_one.save()
 
-    params = {"name": "Name one", **EMPTY_LEVELS_CREATE_PRE_CONFIG_PARAMS}
+    params = {"name": "Name one", **CREATE_PRE_CONFIG_PARAMS}
 
     response = client.post("/pre-configs", json=params)
 
@@ -70,7 +63,7 @@ def test_create_pre_config_not_unique_name(client):
 
 
 def test_pre_config(client):
-    pre_config_one = PreConfig(name="abc", **PRE_CONFIG_FIELDS_EXAMPLE)
+    pre_config_one = PreConfig(name="abc", **CREATE_PRE_CONFIG_PARAMS)
     pre_config_one.save()
 
     response = client.get("/pre-configs")
@@ -83,7 +76,7 @@ def test_pre_config(client):
 
 
 def test_unique_pre_config(client):
-    pre_config = PreConfig(name="def", **PRE_CONFIG_FIELDS_EXAMPLE)
+    pre_config = PreConfig(name="def", **CREATE_PRE_CONFIG_PARAMS)
     pre_config.save()
 
     response = client.get(f"/pre-configs/{pre_config.pk}")

--- a/tests/integration/test_preconfig.py
+++ b/tests/integration/test_preconfig.py
@@ -103,7 +103,7 @@ def test_create_pre_config_invalid_field_types(client):
     assert expected_msg in str(error.value)
 
 
-def test_pre_config_show(client):
+def test_pre_config_show_success(client):
     pre_config = PreConfig(name="def", **CREATE_PRE_CONFIG_PARAMS)
     pre_config.save()
 
@@ -111,6 +111,13 @@ def test_pre_config_show(client):
 
     assert response.status_code == 200
     assert response.json == pre_config.to_json()
+
+
+def test_pre_config_show_error(client):
+    response = client.get("/pre-configs/123")
+
+    assert response.status_code == 404
+    assert response.json["error"] == "123 is not a valid ID"
 
 
 def test_update_pre_config_name_success(client):


### PR DESCRIPTION
## Descrição
Criamos os endpoints para mandar as informações go Service para o CLI, com seus testes

[Visualizar pré configuração do modelo](https://github.com/fga-eps-mds/2021-2-MeasureSoftGram-Doc/issues/53)

## Porque este Pull Request é necessário?
É necessário fazer os endpoints para conseguir fazer os comandos de listar as pré configurações e mostrar as informações da pré configuração escolhida pelo usuário no CLI.

## Critérios de aceitação

- [ ] O usuário deve ter disponível um comando (list) para vizualizar a lista de todas as pré configurações existentes
- [ ] Em cada pré configuração da lista deve ser apresentado o ID, data de criação, nome do arquivo (se houver) 
- [ ] Quando a pré configuração for escolhida, deve ser apresentado um detalhamento daquela pré configuração
- [ ] Deve haver um comando (show) para selecionar a pré configuração desejada
- [ ] Exibir uma mensagem de erro caso a pré configuração escolhida não exista

Closes #numero_da_issue
