### PR TITLE
Salva e envia valores dos valores ponderados da análise

### DIFF
--- a/src/model/analysis.py
+++ b/src/model/analysis.py
@@ -6,6 +6,9 @@ class AnalysisComponents(me.Document):
     sqc = me.DictField()
     aggregated_scs = me.DictField()
     aggregated_characteristics = me.DictField()
+    weighted_measures = me.DictField()
+    weighted_scs = me.DictField()
+    weighted_c = me.DictField()
 
     def to_json(self):
         return {
@@ -13,4 +16,7 @@ class AnalysisComponents(me.Document):
             "sqc": self.sqc,
             "aggregated_scs": self.aggregated_scs,
             "aggregated_characteristics": self.aggregated_characteristics,
+            "weighted_measures": self.weighted_measures,
+            "weighted_scs": self.weighted_scs,
+            "weighted_c": self.weighted_c,
         }

--- a/src/resources/analysis.py
+++ b/src/resources/analysis.py
@@ -55,6 +55,9 @@ class Analysis(Resource):
                     "sqc": analysis_json["sqc"],
                     "characteristics": analysis_json["aggregated_characteristics"],
                     "subcharacteristics": analysis_json["aggregated_scs"],
+                    "weighted_measures": analysis_json["weighted_measures"],
+                    "weighted_subcharacteristics": analysis_json["weighted_scs"],
+                    "weighted_characteristics": analysis_json["weighted_c"],
                 },
             }, requests.codes.ok
 
@@ -68,11 +71,16 @@ class Analysis(Resource):
         if not 200 <= resultado.status_code <= 299:
             return resultado.json(), resultado.status_code
 
+        analysis_json = resultado.json()
+
         AnalysisComponents(
             pre_config_id=data["pre_config_id"],
-            sqc=resultado.json()["sqc"],
-            aggregated_scs=resultado.json()["subcharacteristics"],
-            aggregated_characteristics=resultado.json()["characteristics"],
+            sqc=analysis_json["sqc"],
+            aggregated_scs=analysis_json["subcharacteristics"],
+            aggregated_characteristics=analysis_json["characteristics"],
+            weighted_measures=analysis_json["weighted_measures"],
+            weighted_scs=analysis_json["weighted_subcharacteristics"],
+            weighted_c=analysis_json["weighted_characteristics"],
         ).save()
 
         data_to_return = {

--- a/tests/integration/test_analysis.py
+++ b/tests/integration/test_analysis.py
@@ -90,6 +90,15 @@ class AnalysisResultsResponse:
                 "maintainability": 0.5,
                 "reliability": 0.7142857142857143,
             },
+            "weighted_characteristics": {
+                "maintainability": 0.5,
+                "reliability": 0.7142857142857143,
+            },
+            "weighted_subcharacteristics": {
+                "modifiability": 0.5,
+                "testing_status": 0.7142857142857143,
+            },
+            "weighted_measures": {"m1": 0.8},
         }
 
 
@@ -176,6 +185,15 @@ def test_analysis_already_exists(client, mocker):
             "maintainability": 0.42857142857142855,
             "reliability": 1,
         },
+        weighted_c={
+            "maintainability": 0.5,
+            "reliability": 0.7142857142857143,
+        },
+        weighted_scs={
+            "modifiability": 0.5,
+            "testing_status": 0.7142857142857143,
+        },
+        weighted_measures={"m1": 0.8},
     ).save()
 
     data = {"pre_config_id": pre_configuration_id}
@@ -192,6 +210,15 @@ def test_analysis_already_exists(client, mocker):
             "maintainability": 0.42857142857142855,
             "reliability": 1,
         },
+        "weighted_characteristics": {
+            "maintainability": 0.5,
+            "reliability": 0.7142857142857143,
+        },
+        "weighted_subcharacteristics": {
+            "modifiability": 0.5,
+            "testing_status": 0.7142857142857143,
+        },
+        "weighted_measures": {"m1": 0.8},
     }
 
     assert response.status_code == 200
@@ -260,6 +287,15 @@ def test_analysis_success(client, mocker):
             "maintainability": 0.5,
             "reliability": 0.7142857142857143,
         },
+        "weighted_characteristics": {
+            "maintainability": 0.5,
+            "reliability": 0.7142857142857143,
+        },
+        "weighted_subcharacteristics": {
+            "modifiability": 0.5,
+            "testing_status": 0.7142857142857143,
+        },
+        "weighted_measures": {"m1": 0.8},
     }
 
     assert response.status_code == 201


### PR DESCRIPTION
# Salva e envia valores dos valores ponderados da análise

## Descrição
Permite que a análise salve os valores ponderados e que estes também sejam enviados quando solicitado
